### PR TITLE
Add customization options for Loki labels

### DIFF
--- a/Sources/LoggingLoki/BatchEntry.swift
+++ b/Sources/LoggingLoki/BatchEntry.swift
@@ -1,4 +1,59 @@
+import Foundation
+
 struct BatchEntry {
     var labels: LokiLabels
     var logEntries: [LokiLog]
+    
+    init(labels: LokiLabels, logEntries: [LokiLog]) {
+        self.labels = labels.filterLabels()
+        self.logEntries = logEntries
+    }
+}
+
+private extension LokiLabels {
+    
+    func filterLabels() -> LokiLabels {
+        var result: LokiLabels = [:]
+        for (label, value) in self {
+            result[label.asLokiLabel()] = value
+        }
+        return result
+    }
+}
+
+private extension String {
+    
+    static let allowedLabelCharacters = CharacterSet(charactersIn: "a"..."z")
+        .union(CharacterSet(charactersIn: "A"..."Z"))
+        .union(CharacterSet(charactersIn: "0"..."9"))
+        .union(["_"])
+    
+    static let allowedFirstLabelCharacters = CharacterSet(charactersIn: "a"..."z")
+        .union(CharacterSet(charactersIn: "A"..."Z"))
+        .union(["_"])
+    
+    func asLokiLabel() -> String {
+        guard !isEmpty else { return "_" }
+        var newString = map {
+            if String.allowedLabelCharacters.contains($0) {
+                return $0
+            } else {
+                return "_"
+            }
+        }
+        if !String.allowedFirstLabelCharacters.contains(newString[0]) {
+            newString.insert("_", at: 0)
+        }
+        return String(newString)
+    }
+}
+
+private extension CharacterSet {
+    
+    func contains(_ character: Character) -> Bool {
+        for scalar in character.unicodeScalars {
+            if !contains(scalar) { return false }
+        }
+        return true
+    }
 }

--- a/Sources/LoggingLoki/LokiLabels.swift
+++ b/Sources/LoggingLoki/LokiLabels.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+public extension LokiLogHandler {
+    
+    enum Labels: String, CaseIterable {
+        
+        case level
+        case label
+        case file
+        case line
+        case function
+        case source
+    }
+}
+
+
+public struct LabelsSet: ExpressibleByArrayLiteral, Hashable {
+    
+    public static let empty = LabelsSet(labels: [], isInverted: false)
+    public static let all = LabelsSet(labels: [], isInverted: true)
+    
+    public let labels: Set<String>
+    public let isInverted: Bool
+    
+    public var inverted: LabelsSet {
+        LabelsSet(labels: labels, isInverted: !isInverted)
+    }
+    
+    init(labels: Set<String>, isInverted: Bool) {
+        self.labels = labels
+        self.isInverted = isInverted
+    }
+    
+    public init(_ labels: some Collection<String>) {
+        self.init(labels: Set(labels), isInverted: false)
+    }
+    
+    public init(arrayLiteral elements: String...) {
+        self.init(elements)
+    }
+    
+    public func contains(_ label: String) -> Bool {
+        labels.contains(label) != isInverted
+    }
+}
+

--- a/Sources/LoggingLoki/LokiLogHandler.swift
+++ b/Sources/LoggingLoki/LokiLogHandler.swift
@@ -46,7 +46,7 @@ public struct LokiLogHandler: LogHandler {
         self.batchSize = batchSize
         self.maxBatchTimeInterval = maxBatchTimeInterval
         self.session = session
-				self.includeLabels = includeLabels
+        self.includeLabels = includeLabels
         self.batcher = Batcher(session: self.session,
                                headers: headers,
                                lokiURL: self.lokiURL,
@@ -127,9 +127,7 @@ public struct LokiLogHandler: LogHandler {
             ) { metadata, _ in
                 metadata
             }
-        let metadataString = metadata.isEmpty
-        ? prettyMetadata
-        : prettify(metadata)
+        let metadataString = metadata.isEmpty ? prettyMetadata : prettify(metadata)
         
         let timestamp = Date()
         let message = "[\(level.rawValue.uppercased())]\(metadataString.isEmpty ? "" : " \(metadataString)") \(message)"


### PR DESCRIPTION
This pull request aims to enhance the user experience with Loki by allowing users to customize which metadata is sent as labels. As Loki labels are highly convenient for log querying, this feature will greatly improve usability and efficiency in managing logs.

How to use:
Specify `indexedMetadataKeys` in `LokiLogHandler` init
Built-in labels are available as  `LokiLogHandler.Labels`